### PR TITLE
Feat：Spectrum(光谱世界)钓鱼竿兼容

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ java_version=21
 # Minecraft Info
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1,1.22)
-neo_version=21.1.115
+neo_version=21.1.234
 neo_version_range=[21,)
 loader_version_range=[4,)
 parchment_minecraft_version=1.21.1
@@ -24,3 +24,7 @@ mod_description=A Minecraft Neoforge mod about Fake Player
 # Dependencies Info
 rolling_gate_version=1.1.0+build.51
 aquaculture_version=2.7.13
+spectrum_version=1.11.8-1.21.1-neo
+revelationary_version=1.5.0+1.21.1
+curios_version=9.5.1+1.21.1
+modonomicon_version=1.21.1-1.120.1

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -1,5 +1,13 @@
 dependencies {
     // Rolling Gate
     implementation "dev.anvilcraft.rg:RollingGate:${rolling_gate_version}"
+
+    // Mod Compat
+    // AquaCulture 2
     implementation "com.teammetallurgy.aquaculture:aquaculture2_${minecraft_version}:${minecraft_version}-${aquaculture_version}"
+    // Spectrum
+    implementation "maven.modrinth:spectrum:${spectrum_version}"
+    implementation "maven.modrinth:revelationary:${revelationary_version}"
+    implementation "maven.modrinth:curios:${curios_version}"
+    implementation "maven.modrinth:modonomicon:${modonomicon_version}"
 }

--- a/src/main/java/dev/anvilcraft/rg/sd/mixin/combat/SpectrumFishingHookMixin.java
+++ b/src/main/java/dev/anvilcraft/rg/sd/mixin/combat/SpectrumFishingHookMixin.java
@@ -1,0 +1,24 @@
+package dev.anvilcraft.rg.sd.mixin.combat;
+
+import de.dafuqs.spectrum.entity.entity.SpectrumFishingHook;
+import dev.anvilcraft.rg.sd.SiliconeDollsServerRules;
+import dev.anvilcraft.rg.sd.entity.FakePlayer;
+import dev.anvilcraft.rg.sd.tool.FakePlayerAutoFish;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.projectile.FishingHook;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SpectrumFishingHook.class)
+abstract class SpectrumFishingHookMixin {
+    @Inject(method = "catchingFish", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/syncher/SynchedEntityData;set(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V", ordinal = 1))
+    private void catchingFish(BlockPos pos, CallbackInfo ci) {
+        Entity entity = ((FishingHook) (Object) this).getOwner();
+        if (SiliconeDollsServerRules.fakePlayerAutoFish && entity instanceof FakePlayer player) {
+            FakePlayerAutoFish.autoFish(player);
+        }
+    }
+}

--- a/src/main/resources/silicone_dolls.mixins.json
+++ b/src/main/resources/silicone_dolls.mixins.json
@@ -19,7 +19,8 @@
     "SlotMixin",
     "combat.AquaFishingBobberEntityMixin",
     "combat.PacketDistributorMixin",
-    "combat.ServerCommonPacketListenerImplMixin"
+    "combat.ServerCommonPacketListenerImplMixin",
+    "combat.SpectrumFishingHookMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
使光谱世界的钓鱼竿兼容假人自动钓鱼功能
因光谱世界自行实现了鱼竿浮漂，原有逻辑无法覆盖